### PR TITLE
Fix duplicate clear route

### DIFF
--- a/ipl-tips-backend/routes/matches.js
+++ b/ipl-tips-backend/routes/matches.js
@@ -100,15 +100,6 @@ router.post('/importfixtures/:round', async (req, res) => {
   }
 });
 
-// Delete all matches (for testing/reset)
-router.delete('/clear', async (req, res) => {
-  try {
-    await Match.deleteMany({});
-    res.send("All matches deleted");
-  } catch (err) {
-    res.status(500).send("Failed to delete matches");
-  }
-});
 
 // For importing results (after round is over)
 router.post('/importresults/:round', async (req, res) => {


### PR DESCRIPTION
## Summary
- remove duplicate `/clear` route in matches API

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm test --prefix ipl-tips-backend` *(fails: Error: no test specified)*
- `CI=true npm test --prefix ipl-tips-frontend -- --watchAll=false` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868a01fc5888324aa5e472634b386a3