### PR TITLE
Fix admin import endpoints

### DIFF
--- a/ipl-tips-backend/.npmrc
+++ b/ipl-tips-backend/.npmrc
@@ -1,2 +1,0 @@
-puppeteer_skip_chromium_download=false
-PUPPETEER_PRODUCT=chrome

--- a/ipl-tips-backend/package-lock.json
+++ b/ipl-tips-backend/package-lock.json
@@ -15,7 +15,6 @@
         "dotenv": "^17.0.1",
         "express": "^5.1.0",
         "mongoose": "^8.16.1",
-        "puppeteer": "^24.11.2",
         "react-scripts": "^5.0.1"
       },
       "devDependencies": {

--- a/ipl-tips-backend/package.json
+++ b/ipl-tips-backend/package.json
@@ -18,7 +18,6 @@
     "dotenv": "^17.0.1",
     "express": "^5.1.0",
     "mongoose": "^8.16.1",
-    "puppeteer": "^24.11.2",
     "react-scripts": "^5.0.1"
   },
   "devDependencies": {

--- a/ipl-tips-backend/routes/matches.js
+++ b/ipl-tips-backend/routes/matches.js
@@ -1,14 +1,15 @@
 const express = require('express');
 const router = express.Router();
-const Match = require('../schemas/Match'); // adjust path if needed
-const puppeteer = require("puppeteer");
+const Match = require('../schemas/Match');
+const axios = require('axios');
 
-async function launchBrowser() {
-  return await puppeteer.launch({
-    headless: true,
-    args: ["--no-sandbox", "--disable-setuid-sandbox"],
-  });
-}
+// common headers when calling the dribl API so it looks like a real browser
+const REQUEST_HEADERS = {
+  'User-Agent':
+    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ' +
+    'AppleWebKit/537.36 (KHTML, like Gecko) ' +
+    'Chrome/117.0.0.0 Safari/537.36',
+};
 
 // GET all matches
 // matches.js (Express route)
@@ -36,54 +37,18 @@ router.post('/importfixtures/:round', async (req, res) => {
   const url = `https://mc-api.dribl.com/api/fixtures?league=gld4J2geNW&type_round=roundrobin_${round}`;
 
   try {
-    const browser = await launchBrowser();
-    const page = await browser.newPage();
+    const { data } = await axios.get(url, { headers: REQUEST_HEADERS });
 
-    // Set user-agent (realistic browser)
-    await page.setUserAgent(
-      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ' +
-      'AppleWebKit/537.36 (KHTML, like Gecko) ' +
-      'Chrome/117.0.0.0 Safari/537.36'
-    );
-
-    // Optional: set viewport for good measure
-    await page.setViewport({ width: 1280, height: 800 });
-
-    // Go to the URL and wait for network to be idle
-    const response = await page.goto(url, { waitUntil: 'networkidle2' });
-
-    // Check for status code 200
-    if (!response || response.status() !== 200) {
-      await browser.close();
-      return res.status(response ? response.status() : 500).send("Failed to load data page");
+    if (!data?.data) {
+      return res.status(400).send('No match data found');
     }
 
-    // Wait a bit to ensure any JS finishes (can tweak ms)
-    await new Promise(resolve => setTimeout(resolve, 1000));
-
-    // Grab the raw page content text
-    const bodyText = await page.evaluate(() => document.body.innerText);
-
-    await browser.close();
-
-    // Try parsing JSON
-    let parsed;
-    try {
-      parsed = JSON.parse(bodyText);
-    } catch (jsonErr) {
-      console.error("JSON parse error:", jsonErr.message);
-      console.error("Received data:", bodyText);
-      return res.status(500).send("Failed to parse JSON response");
-    }
-
-    if (!parsed?.data) {
-      return res.status(400).send("No match data found");
-    }
-
-    const newMatches = parsed.data.map(item => {
+    const newMatches = data.data.map((item) => {
       const attr = item.attributes;
-      const utcTime = new Date(attr.date); // from API
-      const auTime = new Date(utcTime.toLocaleString("en-US", { timeZone: "Australia/Sydney" }));
+      const utcTime = new Date(attr.date);
+      const auTime = new Date(
+        utcTime.toLocaleString('en-US', { timeZone: 'Australia/Sydney' })
+      );
       return {
         match_id: item.hash_id,
         round: attr.round,
@@ -91,101 +56,63 @@ router.post('/importfixtures/:round', async (req, res) => {
         away_team: attr.away_team_name.trim(),
         home_score: attr.home_score,
         away_score: attr.away_score,
-        date: auTime
-        
+        date: auTime,
       };
     });
 
-    await Match.deleteMany({ round: "R" + round });
+    await Match.deleteMany({ round: 'R' + round });
     await Match.insertMany(newMatches);
 
     console.log('Matches imported:', newMatches.length);
-    res.send("Imported round " + round);
+    res.send('Imported round ' + round);
   } catch (err) {
-    console.error("Puppeteer import error:", err.message);
-    res.status(500).send("Failed to import matches");
+    console.error('Import error:', err.message);
+    res.status(500).send('Failed to import matches');
   }
 });
 
 
 // For importing results (after round is over)
 router.post('/importresults/:round', async (req, res) => {
-    const round = req.params.round;
-    console.log('Importing round:', round);
-  
-    const url = `https://mc-api.dribl.com/api/results?league=gld4J2geNW&type_round=roundrobin_${round}`;
-  
-    try {
-      const browser = await launchBrowser();
-      const page = await browser.newPage();
-  
-      // Set user-agent (realistic browser)
-      await page.setUserAgent(
-        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ' +
-        'AppleWebKit/537.36 (KHTML, like Gecko) ' +
-        'Chrome/117.0.0.0 Safari/537.36'
-      );
-  
-      // Optional: set viewport for good measure
-      await page.setViewport({ width: 1280, height: 800 });
-  
-      // Go to the URL and wait for network to be idle
-      const response = await page.goto(url, { waitUntil: 'networkidle2' });
-  
-      // Check for status code 200
-      if (!response || response.status() !== 200) {
-        await browser.close();
-        return res.status(response ? response.status() : 500).send("Failed to load data page");
-      }
-  
-      // Wait a bit to ensure any JS finishes (can tweak ms)
-      await new Promise(resolve => setTimeout(resolve, 1000));
-  
-      // Grab the raw page content text
-      const bodyText = await page.evaluate(() => document.body.innerText);
-  
-      await browser.close();
-  
-      // Try parsing JSON
-      let parsed;
-      try {
-        parsed = JSON.parse(bodyText);
-      } catch (jsonErr) {
-        console.error("JSON parse error:", jsonErr.message);
-        console.error("Received data:", bodyText);
-        return res.status(500).send("Failed to parse JSON response");
-      }
-  
-      if (!parsed?.data) {
-        return res.status(400).send("No match data found");
-      }
-  
-      const newMatches = parsed.data.map(item => {
-        const attr = item.attributes;
-        const utcTime = new Date(attr.date); // from API
-        const auTime = new Date(utcTime.toLocaleString("en-US", { timeZone: "Australia/Sydney" }));
-        return {
-          match_id: item.hash_id,
-          round: attr.round,
-          home_team: attr.home_team_name.trim(),
-          away_team: attr.away_team_name.trim(),
-          home_score: attr.home_score,
-          away_score: attr.away_score,
-          date: auTime
-          
-        };
-      });
-  
-      await Match.deleteMany({ round: "R" + round });
-      await Match.insertMany(newMatches);
-  
-      console.log('Matches imported:', newMatches.length);
-      res.send("Imported round " + round);
-    } catch (err) {
-      console.error("Puppeteer import error:", err.message);
-      res.status(500).send("Failed to import matches");
+  const round = req.params.round;
+  console.log('Importing round:', round);
+
+  const url = `https://mc-api.dribl.com/api/results?league=gld4J2geNW&type_round=roundrobin_${round}`;
+
+  try {
+    const { data } = await axios.get(url, { headers: REQUEST_HEADERS });
+
+    if (!data?.data) {
+      return res.status(400).send('No match data found');
     }
-  });
+
+    const newMatches = data.data.map((item) => {
+      const attr = item.attributes;
+      const utcTime = new Date(attr.date);
+      const auTime = new Date(
+        utcTime.toLocaleString('en-US', { timeZone: 'Australia/Sydney' })
+      );
+      return {
+        match_id: item.hash_id,
+        round: attr.round,
+        home_team: attr.home_team_name.trim(),
+        away_team: attr.away_team_name.trim(),
+        home_score: attr.home_score,
+        away_score: attr.away_score,
+        date: auTime,
+      };
+    });
+
+    await Match.deleteMany({ round: 'R' + round });
+    await Match.insertMany(newMatches);
+
+    console.log('Matches imported:', newMatches.length);
+    res.send('Imported round ' + round);
+  } catch (err) {
+    console.error('Import error:', err.message);
+    res.status(500).send('Failed to import matches');
+  }
+});
 
   // GET /api/matches/rounds - returns array of rounds e.g. ["R1", "R2", "R3"]
 router.get('/rounds', async (req, res) => {

--- a/ipl-tips-backend/utils/scoring.js
+++ b/ipl-tips-backend/utils/scoring.js
@@ -1,43 +1,22 @@
 const User = require("../schemas/User");
-const puppeteer = require("puppeteer");
+const axios = require("axios");
 
-async function launchBrowser() {
-  return await puppeteer.launch({
-    headless: true,
-    args: ["--no-sandbox", "--disable-setuid-sandbox"],
-  });
-}
+const REQUEST_HEADERS = {
+  "User-Agent":
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) " +
+    "AppleWebKit/537.36 (KHTML, like Gecko) " +
+    "Chrome/117.0.0.0 Safari/537.36",
+};
 
 async function calculateScores(roundNumber) {
   const url = `https://mc-api.dribl.com/api/results?league=gld4J2geNW&type_round=roundrobin_${roundNumber}`;
 
-  // Launch Puppeteer and fetch results JSON text
-  const browser = await launchBrowser();
-  const page = await browser.newPage();
-
-  // Set user agent to look like a normal browser
-  await page.setUserAgent(
-    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) ' +
-    'AppleWebKit/537.36 (KHTML, like Gecko) ' +
-    'Chrome/117.0.0.0 Safari/537.36'
-  );
-
-  const response = await page.goto(url, { waitUntil: 'networkidle2' });
-
-  if (!response || response.status() !== 200) {
-    await browser.close();
-    throw new Error(`Failed to load results page, status: ${response ? response.status() : 'no response'}`);
-  }
-
-  // Get the page text content (the JSON response)
-  const bodyText = await page.evaluate(() => document.body.innerText);
-  await browser.close();
-
   let parsed;
   try {
-    parsed = JSON.parse(bodyText);
+    const { data } = await axios.get(url, { headers: REQUEST_HEADERS });
+    parsed = data;
   } catch (err) {
-    throw new Error(`Failed to parse results JSON: ${err.message}`);
+    throw new Error(`Failed to fetch results: ${err.message}`);
   }
 
   const matches = parsed.data; // your JSON has results under data

--- a/ipl-tips-frontend/src/App.js
+++ b/ipl-tips-frontend/src/App.js
@@ -15,8 +15,14 @@ function App() {
         <Route path="*" element={<Navigate to="/" />} />
         <Route path="/tips" element={<TipPage />} />
         <Route path="/leaderboard" element={<LeaderboardPage />} />
-        <Route path="/admin" element={<AdminPage />} />
-        <Route path="/admin" element={<AdminOnlyRoute><AdminPage /></AdminOnlyRoute>} />
+        <Route
+          path="/admin"
+          element={
+            <AdminOnlyRoute>
+              <AdminPage />
+            </AdminOnlyRoute>
+          }
+        />
       </Routes>
     </BrowserRouter>
   );

--- a/ipl-tips-frontend/src/components/AdminOnlyRoute.js
+++ b/ipl-tips-frontend/src/components/AdminOnlyRoute.js
@@ -2,6 +2,6 @@ import { Navigate } from "react-router-dom";
 
 export default function AdminOnlyRoute({ children }) {
   const username = localStorage.getItem("username");
-  if (username !== "admin") return <Navigate to="/login" />;
+  if (username !== "admin") return <Navigate to="/" />;
   return children;
 }


### PR DESCRIPTION
## Summary
- replace puppeteer with axios for importing fixtures/results
- switch scoring util to axios
- drop puppeteer from backend dependencies
- remove leftover npmrc
- secure admin route

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm test` in backend *(fails: Error: no test specified)*
- `npm test --silent` in frontend *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868fe5a039c83249b4d6a3cfd891048